### PR TITLE
ビュー崩れ修正2

### DIFF
--- a/app/assets/stylesheets/signup/_signup.scss
+++ b/app/assets/stylesheets/signup/_signup.scss
@@ -1,5 +1,6 @@
 .wrapper {
   width: 100%;
+  height: 1069px;
   background-color: $body;
 
   .main-wrapper {
@@ -85,7 +86,7 @@
             width: 20px;
             position: absolute;
             left: 80px;
-            top: 217px;
+            top: 212px;
           }
         }
       }


### PR DESCRIPTION
# WHAT
新規会員登録画面のgoogleアイコン位置とbodyのheightが崩れた問題を修正

（原因）
不明

（対応）
- signup.scssファイルのwrapperへ高さを1069PXで直接指定
- signup.scssの &__icon_googleでずれた分の位置を再度指定

# WHY
ビューを正しい状態に戻すため